### PR TITLE
change repoUrl configuration to PawbSocial github

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -3,7 +3,7 @@ import { getStaticDir } from "@utils/env";
 export const favIconUrl = `${getStaticDir()}/assets/icons/favicon.svg`;
 export const favIconPngUrl = `${getStaticDir()}/assets/icons/apple-touch-icon.png`;
 
-export const repoUrl = "https://github.com/LemmyNet";
+export const repoUrl = "https://github.com/PawbSocial";
 export const joinLemmyUrl = "https://join-lemmy.org";
 export const donateLemmyUrl = `${joinLemmyUrl}/donate`;
 export const docsUrl = `${joinLemmyUrl}/docs/en/index.html`;


### PR DESCRIPTION
Clicking the "code" hyperlink at the bottom of the pawb.social web site links to the LemmyNet github account.
This PR changes the hyperlink to the PawbSocial github account.